### PR TITLE
setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ Monitor npub across relays
 git clone https://github.com/AusDavo/nostr-dead-man-switch.git
 cd nostr-dead-man-switch
 
+# Copy example .env file
+
 # Generate a bot keypair
 docker compose run --rm deadman --generate-key
 
 # Set up secrets
-cp .env.example .env
 # Edit .env with the bot nsec you just generated (and SMTP password if using email)
 
 # Set up config

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ git clone https://github.com/AusDavo/nostr-dead-man-switch.git
 cd nostr-dead-man-switch
 
 # Copy example .env file
+cp .env.example .env
 
 # Generate a bot keypair
 docker compose run --rm deadman --generate-key


### PR DESCRIPTION
I got errors about a missing .env file when generating a key pair before copying the .env.example file.