### PR TITLE
fix: remove actions [] footgun in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,7 +61,8 @@ state_file: "/data/state.json"
 # Everything below fires when the switch triggers.
 # Uncomment the actions you want. You can use as many as you need.
 
-actions: []
+# Uncomment one or more actions below (leave absent for no trigger actions).
+actions:
 
   # ────────────────────────────────────────────────────────
   # EMAIL


### PR DESCRIPTION
`config.example.yaml` had `actions: []` above commented action blocks. If someone uncommented an email (or webhook) entry but left the empty list, YAML parsing fails in a confusing way because `actions` is already a sequence.

I dropped the `[]`, left `actions:` with a short comment, and kept the commented examples indented the same way. That matches the approach in #27 so newcomers can uncomment a block without fighting the parser.

Fixes #27
