### PR TITLE
fix: remove actions: [] YAML footgun in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,7 +61,8 @@ state_file: "/data/state.json"
 # Everything below fires when the switch triggers.
 # Uncomment the actions you want. You can use as many as you need.
 
-actions: []
+# Uncomment one or more actions below (do not use `actions: []` with sibling entries).
+actions:
 
   # ────────────────────────────────────────────────────────
   # EMAIL

--- a/config_test.go
+++ b/config_test.go
@@ -76,6 +76,28 @@ check_interval: 1h
 	}
 }
 
+func TestConfigNullActionsAllowsUncommentedSibling(t *testing.T) {
+	path := writeTempConfig(t, `watch_pubkey: 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d
+bot_nsec: 0000000000000000000000000000000000000000000000000000000000000001
+silence_threshold: 7d
+warning_interval: 1d
+warning_count: 2
+check_interval: 1h
+actions:
+
+  # - type: webhook
+  #   config:
+  #     url: https://example.invalid
+`)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Actions) != 0 {
+		t.Fatalf("Actions = %+v, want empty slice for null actions", cfg.Actions)
+	}
+}
+
 func TestConfigExplicitFederationV1TrueStaysTrue(t *testing.T) {
 	// Belt-and-braces: watch_pubkey set but operator also set federation_v1: true.
 	// Explicit wins.


### PR DESCRIPTION
## Summary
- Replace `actions: []` with null `actions:` so uncommenting an action block parses
- Add regression test for null `actions` with commented siblings

Fixes #27

## Test plan
- [x] `go test -run TestConfigNullActions`