### PR TITLE
Convert admin pages to the light "document" system (v0.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] — 2026-06-02
+
+Visual release. Completes the light "document" rebrand across the
+authenticated admin pages. No behavior, config, or API changes.
+
+### Changed
+
+- **Admin pages now match the document design.** The watcher setup,
+  generated-key, configuration, and roster pages move off the legacy
+  palette shim onto the document system: oxblood accent, monospace
+  section labels, and hairline rules in place of rounded cards — the same
+  vocabulary as the status page and public surfaces.
+- The configuration editor's field grid collapses to a single column on
+  phone-width screens; it previously overflowed the viewport.
+
+### Removed
+
+- Retired the now-unused legacy CSS token aliases (`--bg`, `--card`,
+  `--accent`, `--border`, `--text`, `--muted`, `--accent-ink`) from the
+  shared stylesheet. Only the paper/ink/oxblood and semantic-state tokens
+  remain.
+
 ## [0.2.3] — 2026-06-01
 
 Visual release. The web UI is rebranded from a dark dashboard to a light

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -675,7 +675,7 @@ var adminHubTemplate = template.Must(template.New("adminHub").Parse(`<!DOCTYPE h
   .relay-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
   .relay-url { font-size: 0.8rem; color: var(--ink); font-family: var(--font-mono); }
   .note-detail { font-size: var(--text-sm); color: var(--ink-muted); line-height: 1.5; }
-  .note-detail code { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text); word-break: break-all; }
+  .note-detail code { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--ink); word-break: break-all; }
   @media (max-width: 480px) { .stat-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
@@ -778,21 +778,20 @@ var watcherSetupTemplate = template.Must(template.New("watcherSetup").Parse(`<!D
 <style>` + baseCSS + `
   .container { max-width: 640px; }
   h1 { justify-content: space-between; margin-bottom: 0.35rem; }
-  .lead { color: var(--muted); font-size: var(--text-sm); line-height: 1.5; margin-bottom: 1.5rem; }
-  .card-title { font-size: var(--text-sm); font-weight: 600; color: var(--text); text-transform: none; letter-spacing: normal; margin-bottom: 0.5rem; }
-  .muted { color: var(--muted); font-size: var(--text-sm); line-height: 1.5; margin-bottom: 0.75rem; }
-  label.consent { display: flex; gap: 0.5rem; align-items: flex-start; font-size: var(--text-xs); color: var(--muted); margin: 0.75rem 0; line-height: 1.4; }
+  .lead { color: var(--ink-muted); font-size: var(--text-sm); line-height: 1.5; margin-bottom: 1.5rem; }
+  .muted { color: var(--ink-muted); font-size: var(--text-sm); line-height: 1.5; margin-bottom: 0.75rem; }
+  label.consent { display: flex; gap: 0.5rem; align-items: flex-start; font-size: var(--text-xs); color: var(--ink-muted); margin: 0.75rem 0; line-height: 1.4; }
   label.consent input { margin-top: 0.2rem; }
   textarea { width: 100%; min-height: 96px; }
-  button.primary { padding: 0.6rem 1rem; border-radius: 0.4rem; border: 1px solid var(--accent); background: var(--accent); color: var(--accent-ink); font-size: var(--text-sm); font-weight: 600; cursor: pointer; font-family: inherit; width: 100%; }
+  button.primary { padding: 0.6rem 1rem; border-radius: 3px; border: 1px solid var(--oxblood); background: var(--oxblood); color: var(--paper); font-size: var(--text-sm); font-weight: 600; cursor: pointer; font-family: inherit; width: 100%; }
   button.primary:hover { filter: brightness(1.05); }
-  button.ghost { padding: 0.55rem 0.9rem; border-radius: 0.4rem; border: 1px solid var(--accent); background: transparent; color: var(--accent); font-size: var(--text-sm); cursor: pointer; font-family: inherit; }
-  button.ghost:hover { background: var(--accent); color: var(--accent-ink); }
+  button.ghost { padding: 0.55rem 0.9rem; border-radius: 3px; border: 1px solid var(--oxblood); background: transparent; color: var(--oxblood); font-size: var(--text-sm); cursor: pointer; font-family: inherit; }
+  button.ghost:hover { background: var(--oxblood); color: var(--paper); }
   button.ghost:disabled { opacity: 0.55; cursor: progress; }
   .alert-danger { background: rgba(156,36,28,0.07); border: 1px solid rgba(156,36,28,0.45); color: var(--red); padding: 0.75rem 1rem; border-radius: 3px; font-size: var(--text-sm); margin-bottom: 1.25rem; line-height: 1.5; }
-  .pub { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text); word-break: break-all; background: var(--paper-2); border: 1px solid var(--border); border-radius: 0.4rem; padding: 0.6rem; user-select: all; }
+  .pub { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--ink); word-break: break-all; background: var(--paper-2); border: 1px solid var(--rule); border-radius: 3px; padding: 0.6rem; user-select: all; }
   .reveal-row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 0.75rem; }
-  pre.secret { background: var(--paper-2); border: 1px solid var(--red); border-radius: 0.4rem; padding: 0.75rem; margin-top: 0.75rem; font-family: var(--font-mono); font-size: var(--text-xs); word-break: break-all; white-space: pre-wrap; user-select: all; color: var(--text); display: none; }
+  pre.secret { background: var(--paper-2); border: 1px solid var(--red); border-radius: 3px; padding: 0.75rem; margin-top: 0.75rem; font-family: var(--font-mono); font-size: var(--text-xs); word-break: break-all; white-space: pre-wrap; user-select: all; color: var(--ink); display: none; }
   pre.secret.shown { display: block; }
   .reveal-err { color: var(--red); font-size: var(--text-xs); margin-top: 0.5rem; display: none; }
   .reveal-err.shown { display: block; }
@@ -954,11 +953,11 @@ var watcherGeneratedTemplate = template.Must(template.New("watcherGenerated").Pa
   .container { max-width: 640px; }
   h1 { margin-bottom: 0.35rem; }
   .alert-danger { background: rgba(156,36,28,0.07); border: 1px solid rgba(156,36,28,0.45); color: var(--red); padding: 0.9rem 1rem; border-radius: 3px; font-size: var(--text-sm); margin-bottom: 1.25rem; line-height: 1.55; }
-  pre.secret { background: var(--paper-2); border: 1px solid var(--border); border-radius: 0.4rem; padding: 0.9rem; font-family: var(--font-mono); font-size: var(--text-sm); word-break: break-all; white-space: pre-wrap; user-select: all; }
-  .pub { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--muted); word-break: break-all; }
-  button.copy { margin-top: 0.75rem; padding: 0.5rem 0.9rem; border-radius: 0.4rem; border: 1px solid var(--accent); background: transparent; color: var(--accent); font-size: var(--text-sm); cursor: pointer; font-family: inherit; }
-  button.copy:hover { background: var(--accent); color: var(--accent-ink); }
-  a.primary { padding: 0.7rem 1rem; border-radius: 0.4rem; border: 1px solid var(--accent); background: var(--accent); color: var(--accent-ink); text-decoration: none; text-align: center; font-size: var(--text-sm); font-weight: 600; display: block; }
+  pre.secret { background: var(--paper-2); border: 1px solid var(--rule); border-radius: 3px; padding: 0.9rem; font-family: var(--font-mono); font-size: var(--text-sm); word-break: break-all; white-space: pre-wrap; user-select: all; }
+  .pub { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--ink-muted); word-break: break-all; }
+  button.copy { margin-top: 0.75rem; padding: 0.5rem 0.9rem; border-radius: 3px; border: 1px solid var(--oxblood); background: transparent; color: var(--oxblood); font-size: var(--text-sm); cursor: pointer; font-family: inherit; }
+  button.copy:hover { background: var(--oxblood); color: var(--paper); }
+  a.primary { padding: 0.7rem 1rem; border-radius: 3px; border: 1px solid var(--oxblood); background: var(--oxblood); color: var(--paper); text-decoration: none; text-align: center; font-size: var(--text-sm); font-weight: 600; display: block; }
   a.primary:hover { filter: brightness(1.05); }
 </style>
 </head>
@@ -1186,23 +1185,24 @@ var adminConfigTemplate = template.Must(template.New("adminConfig").Parse(`<!DOC
   .container { max-width: 720px; }
   h1 { justify-content: space-between; }
   .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
-  label { display: block; font-size: var(--text-xs); color: var(--muted); margin-bottom: 0.75rem; }
+  label { display: block; font-size: var(--text-xs); color: var(--ink-muted); margin-bottom: 0.75rem; }
   label span.k { display: block; margin-bottom: 0.25rem; }
   input, textarea, select { width: 100%; }
   textarea { min-height: 80px; }
-  .muted { color: var(--muted); font-size: var(--text-xs); line-height: 1.5; margin-bottom: 0.75rem; }
-  button.primary { padding: 0.55rem 0.9rem; border-radius: 0.4rem; border: 1px solid var(--accent); background: var(--accent); color: var(--accent-ink); font-size: var(--text-sm); font-weight: 600; cursor: pointer; font-family: inherit; }
+  .muted { color: var(--ink-muted); font-size: var(--text-xs); line-height: 1.5; margin-bottom: 0.75rem; }
+  button.primary { padding: 0.55rem 0.9rem; border-radius: 3px; border: 1px solid var(--oxblood); background: var(--oxblood); color: var(--paper); font-size: var(--text-sm); font-weight: 600; cursor: pointer; font-family: inherit; }
   button.primary:hover { filter: brightness(1.05); }
-  button.secondary { padding: 0.55rem 0.9rem; border-radius: 0.4rem; background: transparent; color: var(--text); border: 1px solid var(--border); font-size: var(--text-sm); font-weight: 500; cursor: pointer; font-family: inherit; transition: border-color 120ms ease-out, color 120ms ease-out; }
-  button.secondary:hover { border-color: var(--accent); color: var(--accent); }
-  button.danger { padding: 0.55rem 0.9rem; border-radius: 0.4rem; background: transparent; color: var(--red); border: 1px solid rgba(156,36,28,0.4); font-size: var(--text-sm); font-weight: 500; cursor: pointer; font-family: inherit; }
+  button.secondary { padding: 0.55rem 0.9rem; border-radius: 3px; background: transparent; color: var(--ink); border: 1px solid var(--rule); font-size: var(--text-sm); font-weight: 500; cursor: pointer; font-family: inherit; transition: border-color 120ms ease-out, color 120ms ease-out; }
+  button.secondary:hover { border-color: var(--oxblood); color: var(--oxblood); }
+  button.danger { padding: 0.55rem 0.9rem; border-radius: 3px; background: transparent; color: var(--red); border: 1px solid rgba(156,36,28,0.4); font-size: var(--text-sm); font-weight: 500; cursor: pointer; font-family: inherit; }
   button.danger:hover { background: rgba(156,36,28,0.08); }
-  .action { border: 1px solid var(--border); border-radius: 0.4rem; padding: 0.9rem; margin-bottom: 0.75rem; }
-  .action-head { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem; }
-  .action-head .action-index { font-size: var(--text-xs); color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
+  .action { border: 1px solid var(--rule); border-radius: 3px; padding: 0.9rem; margin-bottom: 0.75rem; }
+  .action-head { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem 0.75rem; margin-bottom: 0.75rem; }
+  .action-head .action-type { flex: 1; min-width: 9rem; }
+  .action-head .action-index { font-size: var(--text-xs); color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.08em; }
   .action-head .spacer { flex: 1; }
   .type-fields { display: none; }
-  .msg { font-size: var(--text-sm); padding: 0.6rem 0.75rem; border-radius: 0.4rem; margin-bottom: 1rem; display: none; white-space: pre-wrap; }
+  .msg { font-size: var(--text-sm); padding: 0.6rem 0.75rem; border-radius: 3px; margin-bottom: 1rem; display: none; white-space: pre-wrap; }
   .msg.err { display: block; background: rgba(156,36,28,0.08); border: 1px solid rgba(156,36,28,0.4); color: var(--red); }
   .msg.ok { display: block; background: rgba(47,107,58,0.08); border: 1px solid rgba(47,107,58,0.4); color: var(--green); }
   .card-actions { display: flex; gap: 0.5rem; align-items: center; }
@@ -1210,17 +1210,21 @@ var adminConfigTemplate = template.Must(template.New("adminConfig").Parse(`<!DOC
   .dur .dur-n { flex: 1; min-width: 0; }
   .dur .dur-u { flex: 0 0 auto; width: auto; }
   .dur .dur-raw { flex: 1; }
-  .dur-toggle { background: none; border: none; color: var(--muted); font-size: var(--text-xs); cursor: pointer; padding: 0.2rem 0; margin-top: 0.15rem; font-family: inherit; }
-  .dur-toggle:hover { color: var(--accent); }
-  details { background: var(--card); border: 1px solid var(--border); border-radius: 0.5rem; padding: 1rem 1.25rem; margin-bottom: 1rem; }
-  details > summary { cursor: pointer; font-size: var(--text-sm); color: var(--muted); }
-  details[open] > summary { margin-bottom: 0.75rem; color: var(--text); }
+  .dur-toggle { background: none; border: none; color: var(--ink-muted); font-size: var(--text-xs); cursor: pointer; padding: 0.2rem 0; margin-top: 0.15rem; font-family: inherit; }
+  .dur-toggle:hover { color: var(--oxblood); }
+  details { background: var(--paper-2); border: 1px solid var(--rule); border-radius: 3px; padding: 1rem 1.25rem; margin-bottom: 1rem; }
+  details > summary { cursor: pointer; font-size: var(--text-sm); color: var(--ink-muted); }
+  details[open] > summary { margin-bottom: 0.75rem; color: var(--ink); }
   #raw-json { min-height: 280px; font-size: var(--text-xs); }
   .footer-actions { display: flex; gap: 0.5rem; margin-top: 1rem; }
   .footer-actions > * { flex: 1; }
   .footer-actions form { margin: 0; }
-  .footer-actions a, .footer-actions form button { width: 100%; padding: 0.6rem 0.75rem; border-radius: 0.4rem; border: 1px solid var(--border); background: transparent; color: var(--text); text-decoration: none; text-align: center; font-size: var(--text-sm); font-weight: 500; cursor: pointer; font-family: inherit; display: block; transition: border-color 120ms ease-out, color 120ms ease-out; }
-  .footer-actions a:hover, .footer-actions form button:hover { border-color: var(--accent); color: var(--accent); }
+  .footer-actions a, .footer-actions form button { width: 100%; padding: 0.6rem 0.75rem; border-radius: 3px; border: 1px solid var(--rule); background: transparent; color: var(--ink); text-decoration: none; text-align: center; font-size: var(--text-sm); font-weight: 500; cursor: pointer; font-family: inherit; display: block; transition: border-color 120ms ease-out, color 120ms ease-out; }
+  .footer-actions a:hover, .footer-actions form button:hover { border-color: var(--oxblood); color: var(--oxblood); }
+  @media (max-width: 560px) {
+    .grid-2 { grid-template-columns: 1fr; }
+    .footer-actions { flex-direction: column; }
+  }
 </style>
 </head>
 <body>

--- a/admin_roster.go
+++ b/admin_roster.go
@@ -256,26 +256,25 @@ var rosterTemplate = template.Must(template.New("roster").Parse(`<!DOCTYPE html>
   td.npub, td.code { font-family: var(--font-mono); font-size: var(--text-xs); word-break: break-all; }
   .pill { display: inline-block; padding: 0.12rem 0.45rem; border-radius: 2px; font-family: var(--font-mono); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.04em; border: 1px solid var(--rule); }
   .pill.run { color: var(--green); border-color: rgba(47,107,58,0.4); }
-  .pill.stop { color: var(--muted); }
-  .pill.redeemed { color: var(--muted); }
+  .pill.stop { color: var(--ink-muted); }
+  .pill.redeemed { color: var(--ink-muted); }
   .pill.revoked { color: var(--red); border-color: rgba(156,36,28,0.4); }
   .pill.available { color: var(--green); border-color: rgba(47,107,58,0.4); }
-  .muted { color: var(--muted); font-size: var(--text-xs); line-height: 1.5; margin-bottom: 0.75rem; }
-  .flash { background: rgba(138,90,18,0.08); border: 1px solid rgba(138,90,18,0.4); color: var(--yellow); padding: 0.6rem 0.75rem; border-radius: 0.4rem; font-size: var(--text-sm); margin-bottom: 1rem; }
-  .newcode { background: rgba(47,107,58,0.08); border: 1px solid rgba(47,107,58,0.4); color: var(--text); padding: 0.75rem; border-radius: 0.4rem; margin-bottom: 1rem; }
-  .newcode code { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--accent); user-select: all; }
+  .muted { color: var(--ink-muted); font-size: var(--text-xs); line-height: 1.5; margin-bottom: 0.75rem; }
+  .flash { background: rgba(138,90,18,0.08); border: 1px solid rgba(138,90,18,0.4); color: var(--yellow); padding: 0.6rem 0.75rem; border-radius: 3px; font-size: var(--text-sm); margin-bottom: 1rem; }
+  .newcode { background: rgba(47,107,58,0.08); border: 1px solid rgba(47,107,58,0.4); color: var(--ink); padding: 0.75rem; border-radius: 3px; margin-bottom: 1rem; }
+  .newcode code { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--oxblood); user-select: all; }
   .share-row { display: flex; gap: 0.5rem; align-items: stretch; margin-top: 0.5rem; }
   .share-row input { flex: 1; font-family: var(--font-mono); font-size: var(--text-xs); }
   form.inline { display: flex; gap: 0.5rem; align-items: center; margin: 0; }
   form.inline input[type=text] { flex: 1; }
-  button.primary { padding: 0.5rem 0.85rem; border-radius: 0.4rem; border: 1px solid var(--accent); background: var(--accent); color: var(--accent-ink); font-size: var(--text-sm); font-weight: 600; cursor: pointer; font-family: inherit; }
+  button.primary { padding: 0.5rem 0.85rem; border-radius: 3px; border: 1px solid var(--oxblood); background: var(--oxblood); color: var(--paper); font-size: var(--text-sm); font-weight: 600; cursor: pointer; font-family: inherit; }
   button.primary:hover { filter: brightness(1.05); }
-  button.danger { padding: 0.35rem 0.6rem; border-radius: 0.4rem; background: transparent; color: var(--red); border: 1px solid rgba(156,36,28,0.4); font-size: var(--text-xs); cursor: pointer; font-family: inherit; }
+  button.danger { padding: 0.35rem 0.6rem; border-radius: 3px; background: transparent; color: var(--red); border: 1px solid rgba(156,36,28,0.4); font-size: var(--text-xs); cursor: pointer; font-family: inherit; }
   button.danger:hover { background: rgba(156,36,28,0.08); }
-  button.ghost { padding: 0.35rem 0.6rem; border-radius: 0.4rem; background: transparent; color: var(--accent); border: 1px solid var(--accent); font-size: var(--text-xs); cursor: pointer; font-family: inherit; }
-  button.ghost:hover { background: var(--accent); color: var(--accent-ink); }
-  .empty { color: var(--muted); font-style: italic; padding: 0.5rem 0; }
-  .card-title { font-size: var(--text-sm); font-weight: 600; color: var(--text); text-transform: none; letter-spacing: normal; margin-bottom: 0.75rem; }
+  button.ghost { padding: 0.35rem 0.6rem; border-radius: 3px; background: transparent; color: var(--oxblood); border: 1px solid var(--oxblood); font-size: var(--text-xs); cursor: pointer; font-family: inherit; }
+  button.ghost:hover { background: var(--oxblood); color: var(--paper); }
+  .empty { color: var(--ink-muted); font-style: italic; padding: 0.5rem 0; }
 </style>
 </head>
 <body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   deadman:
-    image: ghcr.io/ausdavo/nostr-dead-man-switch:v0.2.3
+    image: ghcr.io/ausdavo/nostr-dead-man-switch:v0.2.4
     ports:
       - "8080:8080"
     volumes:

--- a/templates_shared.go
+++ b/templates_shared.go
@@ -15,13 +15,12 @@ const sharedHead = `<meta charset="utf-8">
 // Newsreader serif (display/figures), system sans (body), JetBrains Mono
 // (protocol values + structural labels). Layout: rules, not cards.
 //
-// NOTE ON TOKENS: the legacy names (--bg, --card, --text, --accent, --border,
-// --yellow ...) are retained and remapped to light values so the per-page
-// <style> blocks that still reference them resolve correctly. New semantic
-// names (--paper, --ink, --ink-muted, --rule, --oxblood) are the going-forward
-// vocabulary. Each template's <style> prepends this, then layers its own.
+// TOKENS: --paper / --paper-2 / --ink / --ink-muted / --rule / --oxblood are
+// the surface + ink + accent vocabulary; --green / --yellow / --red carry
+// semantic state (always paired with a text label, never color alone). Every
+// template's <style> prepends this, then layers its own.
 const baseCSS = `:root {
-  /* semantic (going-forward) */
+  /* surface, ink, accent */
   --paper: #f3f2ef;
   --paper-2: #eceae6;
   --ink: #19181a;
@@ -29,14 +28,7 @@ const baseCSS = `:root {
   --rule: #c9c6c0;
   --oxblood: #7a1f1a;
 
-  /* legacy aliases, remapped to light values */
-  --bg: #f3f2ef;
-  --card: #eceae6;
-  --border: #c9c6c0;
-  --text: #19181a;
-  --muted: #57555a;
-  --accent: #7a1f1a;
-  --accent-ink: #f3f2ef;
+  /* semantic state (darkened for light bg) */
   --green: #2f6b3a;
   --yellow: #8a5a12;
   --red: #9c241c;


### PR DESCRIPTION
## Summary

The v0.2.3 rebrand converted the public surfaces (status, signup) to the light "document" direction but left the authenticated **admin pages** running on `baseCSS`'s legacy-token shim — the global palette flipped light, but their per-page styles still spoke the old `--accent`/`--card`/`--border` vocabulary and rendered as rounded SaaS cards. This finishes the job.

## Changes

- **Watcher setup, generated-key, configuration, and roster** styles remapped to the `--paper`/`--ink`/`--oxblood`/`--rule` vocabulary; rounded radii dropped for the document's 3px corners.
- Removed the per-page `.card-title` overrides so section labels render as the shared mono-uppercase document labels everywhere.
- **Responsive fix:** the config field grid collapses to one column under 560px — it previously overflowed at phone widths.
- **Retired the shim:** the now-unused legacy aliases (`--bg`/`--card`/`--accent`/`--border`/`--text`/`--muted`/`--accent-ink`) are removed from `baseCSS` entirely. Only surface/ink/accent and semantic-state tokens remain.

No markup or handler logic changed.

## Verification

- `go build` / `go vet` / `go test ./...` all pass; edited files are `gofmt`-clean.
- Rendered every admin template across healthy / triggered / fresh-setup / recovery / generated-key / populated-config / populated-roster states and screenshotted them headless — all match the status page's serif masthead + double rule, mono section labels, oxblood actions, dotted-leader rows.
- Confirmed `scrollWidth === clientWidth` (no horizontal overflow) on the three densest pages at narrow width.
- Verified zero references to the removed aliases remain anywhere, so retiring them is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)