### PR TITLE
Add optional HMAC signing to the webhook action

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,8 @@ BOT_NSEC=nsec1...
 # Bearer token for custom webhook endpoints.
 
 # WEBHOOK_TOKEN=your-secret-token-here
+
+# HMAC signing secret for the webhook action's optional "secret" field.
+# Generate with: openssl rand -hex 32
+
+# WEBHOOK_SECRET=your-hmac-signing-secret-here

--- a/README.md
+++ b/README.md
@@ -231,8 +231,29 @@ Works with n8n, Zapier, Make, Home Assistant, custom APIs, etc.
     headers:
       Content-Type: "application/json"
       Authorization: "Bearer ${WEBHOOK_TOKEN}"
+    secret: "${WEBHOOK_SECRET}"   # optional — HMAC-signs the request (see below)
     body: '{"event":"triggered","source":"nostr-dead-man-switch"}'
 ```
+
+#### Verifying webhook signatures
+
+Without verification, anything that knows your endpoint URL can fake a trigger. If you set the optional `secret`, every request carries an `X-Deadman-Signature` header (same convention as GitHub webhooks):
+
+```
+X-Deadman-Signature: sha256=<hex of HMAC-SHA256(secret, request body)>
+```
+
+On the receiving side, recompute the HMAC over the **raw request body** and compare with a constant-time check. Python example:
+
+```python
+import hashlib, hmac
+
+def verify(secret: str, raw_body: bytes, header: str) -> bool:
+    expected = "sha256=" + hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header)
+```
+
+In n8n, add a Crypto node (HMAC-SHA256 over the body with your secret) and an IF node comparing it against the header. Reject requests with a missing or mismatched signature.
 
 ### Nostr note (signed by bot)
 

--- a/actions.go
+++ b/actions.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -85,8 +88,9 @@ func executeWebhook(ctx context.Context, config map[string]any) error {
 		method = m
 	}
 
+	body := getString(config, "body")
 	var bodyReader io.Reader
-	if body := getString(config, "body"); body != "" {
+	if body != "" {
 		bodyReader = strings.NewReader(body)
 	}
 
@@ -101,6 +105,13 @@ func executeWebhook(ctx context.Context, config map[string]any) error {
 		}
 	}
 
+	// Optional HMAC signing so receivers can verify the request came from
+	// this switch. Set after user headers so a stray "headers:" entry can't
+	// shadow the computed signature.
+	if secret := getString(config, "secret"); secret != "" {
+		req.Header.Set("X-Deadman-Signature", signWebhookBody(secret, body))
+	}
+
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -113,6 +124,15 @@ func executeWebhook(ctx context.Context, config map[string]any) error {
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
+}
+
+// signWebhookBody computes the X-Deadman-Signature header value for a
+// webhook body: "sha256=" + hex(HMAC-SHA256(secret, body)), matching
+// GitHub's webhook signature convention.
+func signWebhookBody(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }
 
 // resolveRelays picks the effective relay list for an outbound publish.

--- a/actions_test.go
+++ b/actions_test.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -28,6 +34,79 @@ func TestExecuteNostrDM_ValidationErrors(t *testing.T) {
 				t.Fatalf("err = %v, want substring %q", err, tc.wantSub)
 			}
 		})
+	}
+}
+
+func TestExecuteWebhook_HMACSigning(t *testing.T) {
+	body := `{"event":"triggered"}`
+	secret := "hunter2"
+
+	// Reference signature computed independently of signWebhookBody.
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	wantSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	cases := []struct {
+		name    string
+		config  map[string]any
+		wantSig string
+	}{
+		{
+			"secret set signs body",
+			map[string]any{"body": body, "secret": secret},
+			wantSig,
+		},
+		{
+			"no secret sends no signature",
+			map[string]any{"body": body},
+			"",
+		},
+		{
+			"empty secret sends no signature",
+			map[string]any{"body": body, "secret": ""},
+			"",
+		},
+		{
+			"computed signature wins over headers entry",
+			map[string]any{
+				"body":    body,
+				"secret":  secret,
+				"headers": map[string]any{"X-Deadman-Signature": "sha256=forged"},
+			},
+			wantSig,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotSig string
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotSig = r.Header.Get("X-Deadman-Signature")
+				gotBody, _ = io.ReadAll(r.Body)
+			}))
+			defer srv.Close()
+
+			tc.config["url"] = srv.URL
+			if err := executeWebhook(context.Background(), tc.config); err != nil {
+				t.Fatalf("executeWebhook: %v", err)
+			}
+			if gotSig != tc.wantSig {
+				t.Errorf("X-Deadman-Signature = %q, want %q", gotSig, tc.wantSig)
+			}
+			if string(gotBody) != body {
+				t.Errorf("body = %q, want %q", gotBody, body)
+			}
+		})
+	}
+}
+
+func TestSignWebhookBody_EmptyBody(t *testing.T) {
+	// A GET-style webhook with no body must still produce a valid,
+	// verifiable signature over the empty string.
+	mac := hmac.New(sha256.New, []byte("s"))
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if got := signWebhookBody("s", ""); got != want {
+		t.Errorf("signWebhookBody(s, \"\") = %q, want %q", got, want)
 	}
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -199,6 +199,11 @@ actions:
   # POST/GET/PUT to any URL. Use for n8n, Zapier, Make,
   # Home Assistant, custom APIs, etc.
   #
+  # Optional: set "secret" and every request carries
+  #   X-Deadman-Signature: sha256=<hex HMAC-SHA256(secret, body)>
+  # (GitHub webhook convention) so the receiver can verify the
+  # request really came from this switch. See README.
+  #
   # - type: webhook
   #   config:
   #     url: "https://your-service.example.com/api/deadman"
@@ -206,6 +211,7 @@ actions:
   #     headers:
   #       Content-Type: "application/json"
   #       Authorization: "Bearer ${WEBHOOK_TOKEN}"
+  #     secret: "${WEBHOOK_SECRET}"
   #     body: '{"event":"triggered","source":"nostr-dead-man-switch","message":"No activity for 30+ days"}'
 
   # ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #29.

## What

The webhook action gains an optional `secret` config field. When set, every outgoing request carries:

```
X-Deadman-Signature: sha256=<hex of HMAC-SHA256(secret, request body)>
```

matching GitHub's webhook signature convention, so receiving services (n8n, Home Assistant, custom APIs) can verify a request genuinely came from this switch — and reject spoofed payloads.

## Design notes

- **Backward compatible**: absent or empty `secret` sends requests exactly as before, no header.
- **Header precedence**: the signature is set *after* user-configured `headers:` entries, so a stray or forged `X-Deadman-Signature` in the headers map can't shadow the computed value (covered by a test).
- **Empty-body GET webhooks** still sign (over the empty string) and verify.
- **UI for free**: the admin config view already masks the field (`secretKeyRe` matches `secret`) and `mergeSecretMap` restores it for the per-action Test button — same mechanism `smtp_pass` uses.
- Secret is sourced from `.env` via `${WEBHOOK_SECRET}` like other secrets.

## Docs

README gains a "Verifying webhook signatures" section with a constant-time Python verifier and an n8n note; `config.example.yaml` and `.env.example` gain the corresponding templates.

## Verification

Beyond unit tests: ran the built binary in federation mode, logged in via the Nostr challenge flow, bootstrapped a watcher, and fired `/admin/config/test-action` webhooks at a local capture listener. The captured `X-Deadman-Signature` verified against an independent HMAC implementation (the README's documented method); the no-secret request carried no header; the forged-header and empty-body-GET probes both held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)