### PR TITLE
Release v0.2.5: webhook HMAC signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] — 2026-07-03
+
+### Added
+
+- **Webhook HMAC signing.** The `webhook` action accepts an optional
+  `secret` field. When set, every request carries an
+  `X-Deadman-Signature: sha256=<hex of HMAC-SHA256(secret, body)>`
+  header (GitHub's webhook convention) so receivers — n8n, Home
+  Assistant, custom APIs — can verify a request genuinely came from
+  this switch and reject spoofed payloads. Absent `secret` leaves
+  requests unsigned, exactly as before. The README documents
+  receiver-side verification with a constant-time comparison example.
+  (#29, #44)
+
 ## [0.2.4] — 2026-06-02
 
 Visual release. Completes the light "document" rebrand across the

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Works with n8n, Zapier, Make, Home Assistant, custom APIs, etc.
 
 Without verification, anything that knows your endpoint URL can fake a trigger. If you set the optional `secret`, every request carries an `X-Deadman-Signature` header (same convention as GitHub webhooks):
 
+> **Where the secret lives:** `${VAR}` expansion from `.env` applies to the host `config.yaml` (legacy single-switch mode). On federation deployments, per-user actions are edited in the dashboard's configuration page — paste the secret value there; it is stored per-user and masked in the UI like other secrets.
+
 ```
 X-Deadman-Signature: sha256=<hex of HMAC-SHA256(secret, request body)>
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   deadman:
-    image: ghcr.io/ausdavo/nostr-dead-man-switch:v0.2.4
+    image: ghcr.io/ausdavo/nostr-dead-man-switch:v0.2.5
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
Release prep for v0.2.5 (webhook HMAC signing, #44):

- CHANGELOG entry for 0.2.5
- `docker-compose.yml` image tag → `v0.2.5`
- README: clarifies where the webhook `secret` lives per deployment mode — federation deployments enter it via the dashboard config editor (stored per-user, masked in the UI); `${VAR}` expansion from `.env` applies to the host `config.yaml` in legacy mode

Tag `v0.2.5` follows once this merges; the tag-triggered release workflow will also validate the Node 24 action bumps already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)